### PR TITLE
Update Crafting_Rates.lua

### DIFF
--- a/Crafting_Rates.lua
+++ b/Crafting_Rates.lua
@@ -42,7 +42,7 @@ end
 
 function CraftingRatesNamespace.SetCraftRate(event, player, command)
     if not player then
-        return false
+        return
     end
     local mingmrank = 3
     local PUID = CraftingRatesNamespace.getPlayerCharacterGUID(player)


### PR DESCRIPTION
Returning false here seems to mess with entering commands at the worldserver console because it is not a player, not just config rates commands but all of them.

 I can't take credit for the idea, metallinos on the azerothcore discord helped me figure out why my console wasn't working anymore, and changing this line fixed it for me.

Thanks for making this by the way, really handy script.